### PR TITLE
fix open error in excel

### DIFF
--- a/src/jquery.table2excel.js
+++ b/src/jquery.table2excel.js
@@ -130,7 +130,7 @@
     };
 
     function getFileName(settings) {
-        return ( settings.filename ? settings.filename : "table2excel") + ".xlsx";
+        return ( settings.filename ? settings.filename : "table2excel") + ".xls";
     }
 
     $.fn[ pluginName ] = function ( options ) {


### PR DESCRIPTION
`xlsx` may not to open excel file. If we change it to `xls`, it could open successfully.