### PR TITLE
#28 how to change excel sheet name

### DIFF
--- a/src/jquery.table2excel.js
+++ b/src/jquery.table2excel.js
@@ -26,7 +26,7 @@
             var e = this;
 
             e.template = {
-                head: "<html xmlns:o=\"urn:schemas-microsoft-com:office:office\" xmlns:x=\"urn:schemas-microsoft-com:office:excel\" xmlns=\"http://www.w3.org/TR/REC-html40\"><head><!--[if gte mso 9]><xml><x:ExcelWorkbook><x:ExcelWorksheets>",
+                head: "<html xmlns:o=\"urn:schemas-microsoft-com:office:office\" xmlns:x=\"urn:schemas-microsoft-com:office:excel\" xmlns=\"http://www.w3.org/TR/REC-html40\"><meta http-equiv=\"content-type\" content=\"application/vnd.ms-excel; charset=UTF-8\"><head><!--[if gte mso 9]><xml><x:ExcelWorkbook><x:ExcelWorksheets>",
                 sheet: {
                     head: "<x:ExcelWorksheet><x:Name>",
                     tail: "</x:Name><x:WorksheetOptions><x:DisplayGridlines/></x:WorksheetOptions></x:ExcelWorksheet>"
@@ -50,10 +50,10 @@
                 e.tableRows.push(tempRows);
             });
 
-            e.tableToExcel(e.tableRows, e.settings.name);
+            e.tableToExcel(e.tableRows, e.settings.name, e.settings.sheetName);
         },
 
-        tableToExcel: function (table, name) {
+        tableToExcel: function (table, name, sheetName) {
             var e = this, fullTemplate="", i, link, a;
 
             e.uri = "data:application/vnd.ms-excel;base64,";
@@ -65,17 +65,21 @@
                     return c[p];
                 });
             };
+
+            sheetName = typeof sheetName == "undefined" ? "Sheet" : sheetName;
+
             e.ctx = {
                 worksheet: name || "Worksheet",
-                table: table
+                table: table,
+                sheetName: sheetName,
             };
 
             fullTemplate= e.template.head;
 
             if ( $.isArray(table) ) {
                 for (i in table) {
-                    //fullTemplate += e.template.sheet.head + "{worksheet" + i + "}" + e.template.sheet.tail;
-                    fullTemplate += e.template.sheet.head + "Table" + i + "" + e.template.sheet.tail;
+                      //fullTemplate += e.template.sheet.head + "{worksheet" + i + "}" + e.template.sheet.tail;
+                      fullTemplate += e.template.sheet.head + sheetName + i + e.template.sheet.tail;
                 }
             }
 


### PR DESCRIPTION
I needed to set the sheetname.

It can be set by:

```javascript
$(".table").table2excel({
    exclude: ".noExl",
    name: "Workbookname",
    filename: "Filename",
    sheetName: "Sheetname",
});
```

First i thought multible sheets could be created from multible tables, but i can't make this work. So i didn't implement passing an array of sheetnames to the plugin.

The default name is "Sheet", which is used when no name is passed in.