### PR TITLE
Update jquery.table2excel.js

### DIFF
--- a/src/jquery.table2excel.js
+++ b/src/jquery.table2excel.js
@@ -46,7 +46,17 @@
             $(e.element).each( function(i,o) {
                 var tempRows = "";
                 $(o).find("tr").not(e.settings.exclude).each(function (i,o) {
-                    tempRows += "<tr>" + $(o).html() + "</tr>";
+                    tempRows += "<tr>";
+                    $(p).find("td").not(e.settings.exclude).each(function (i,q) {
+                        var flag = $(q).find(e.settings.exclude) // does this <td> have something with an exclude class
+                        if(flag.length >= 1) {
+                            tempRows += "<td> </td>" // exclude it!!
+                        } else {
+                            tempRows += "<td>" + $(q).html() + "</td>"
+                        }
+                    })
+                     
+                    tempRows += "</tr>";
                 });
                 e.tableRows.push(tempRows);
             });


### PR DESCRIPTION
Extended "exclude" capabilities down to the &lt;td&gt; level.  Original functionality only allowed you to "exclude" an entire &lt;tr&gt;. It is a fairly simple change.

Now if any item in a &lt;td&gt; contains items with the exclude class on it, that &lt;td&gt; will be exported EMPTY.

This is very useful if you have buttons or other controls in your table and do not want to export them. I especially needed it for exporting .NET DataGrids with controls for Add/Change/Delete.