### PR TITLE
Update jquery.table2excel.js

### DIFF
--- a/src/jquery.table2excel.js
+++ b/src/jquery.table2excel.js
@@ -131,18 +131,18 @@
             fullTemplate= e.template.head;
 
             if ( $.isArray(table) ) {
-                for (i in table) {
+                 Object.keys(table).forEach(function(i){
                       //fullTemplate += e.template.sheet.head + "{worksheet" + i + "}" + e.template.sheet.tail;
                       fullTemplate += e.template.sheet.head + sheetName + i + e.template.sheet.tail;
-                }
+                })
             }
 
             fullTemplate += e.template.mid;
 
             if ( $.isArray(table) ) {
-                for (i in table) {
+                 Object.keys(table).forEach(function(i){
                     fullTemplate += e.template.table.head + "{table" + i + "}" + e.template.table.tail;
-                }
+                })
             }
 
             fullTemplate += e.template.foot;


### PR DESCRIPTION
This is used to avoid props in Array.prototype be added in the fullTemplate. For example, some other libraries may add functions on Array.prototype.